### PR TITLE
REDCORE-JavascriptTexts

### DIFF
--- a/libraries/redcore/text/text.php
+++ b/libraries/redcore/text/text.php
@@ -39,4 +39,24 @@ class RText extends JText
 
 		return strtr($string, $replace);
 	}
+
+	/**
+	 * Translate a string into the current language and stores it in the JavaScript language store.
+	 *
+	 * @param   string   $string                The JText key.
+	 * @param   boolean  $jsSafe                Ensure the output is JavaScript safe.
+	 * @param   boolean  $interpretBackSlashes  Interpret \t and \n.
+	 *
+	 * @return  string
+	 */
+	public static function javascriptText($string = null, $jsSafe = false, $interpretBackSlashes = true)
+	{
+		if ($string !== null)
+		{
+			self::script($string, $jsSafe, $interpretBackSlashes);
+			return "Joomla.JText._('" . $string . "')";
+		}
+		else
+			return '';
+	}
 }


### PR DESCRIPTION
For now we have two separate thing, we have to call function to get our string into Javascript strings like this:
JText::script('COM_REDSHOP_KIXO');
and this is usually in the top of the file, second we have to call it in our javascript somewhere like this:
javascript:confirm(Joomla.JText._('COM_REDSHOP_KIXO'))...
when you have many strings that you want to insert it gets confusing if all strings have been included.

with this function you include your string and get the string in one step...
so:
javascript:confirm(<?php echo RText::javascriptText('COM_REDSHOP_KIXO'); ?>)

If you only have to include it on the page and using it in javascript file, just do it like you did before but with this function, but do not echo it at top of the file...
RText::javascriptText('COM_REDSHOP_KIXO');
it will be included in the Javascript texts as well but you only use one method which is easier to remember.

Function name can be different, this was the first thing that was on my mind...
