### PR TITLE
Update fix pagination select box

### DIFF
--- a/libraries/redcore/layouts/pagination/links.php
+++ b/libraries/redcore/layouts/pagination/links.php
@@ -12,11 +12,6 @@ defined('JPATH_REDCORE') or die;
 $list = $displayData['list'];
 $pages = $list['pages'];
 
-if (empty($pages))
-{
-	return null;
-}
-
 $options = new JRegistry($displayData['options']);
 
 $showLimitBox   = $options->get('showLimitBox', true);
@@ -58,7 +53,7 @@ if ($currentPage >= $step)
 			<?php echo JText::_('JGLOBAL_DISPLAY_NUM') . $list['limitfield']; ?>
 		</div>
 	<?php endif; ?>
-	<?php if ($showPagesLinks) : ?>
+	<?php if ($showPagesLinks && (!empty($pages))) : ?>
 		<ul class="pagination-list">
 			<?php
 				echo RLayoutHelper::render('pagination.link', $pages['start']);

--- a/libraries/redcore/pagination/pagination.php
+++ b/libraries/redcore/pagination/pagination.php
@@ -444,7 +444,7 @@ class RPagination
 
 		$list = array(
 			'prefix'       => $this->prefix,
-			'limit'        => $this->limitstart,
+			'limit'        => $this->limit,
 			'limitstart'   => $this->limitstart,
 			'total'        => $this->total,
 			'limitfield'   => $this->getLimitBox(),


### PR DESCRIPTION
- Fix Limitbox:
  Limitbox will disappear when I choose a limit number is larger than current total items. (Ex: I have 7 items, if I choose limit is display #10, this box will be disappear and no come back forever).
