### PR TITLE
Fix JSEARCH language error

### DIFF
--- a/libraries/redcore/layouts/search.php
+++ b/libraries/redcore/layouts/search.php
@@ -40,9 +40,9 @@ if (isset($data['filter_name']))
 <div id="filter-bar" class="btn-toolbar">
 	<div class="filter-search btn-group pull-left">
 		<input type="text" name="filter_<?php echo $filterName ?>" id="filter_<?php echo $filterName ?>" class="js-enter-submits"
-		       placeholder="<?php echo JText::_('JSEARCH'); ?>"
+		       placeholder="<?php echo JText::_('JSEARCH_FILTER'); ?>"
 		       value="<?php echo $state->get('filter.' . $filterName); ?>"
-		       title="<?php echo JText::_('JSEARCH'); ?>"/>
+		       title="<?php echo JText::_('JSEARCH_FILTER'); ?>"/>
 	</div>
 	<div class="btn-group hidden-phone">
 		<button class="btn hasTooltip" type="submit" title="<?php echo JText::_('JSEARCH_FILTER_SUBMIT'); ?>">


### PR DESCRIPTION
Joomla don't use JSEARCH, version 2.5.x and 3.2.x using 'JSEARCH_FILTER' for show a field name.
So I changed it to 'JSEARCH_FILTER'
