### PR TITLE
Fix base64 error on return variable

### DIFF
--- a/libraries/redcore/controller/admin/base.php
+++ b/libraries/redcore/controller/admin/base.php
@@ -348,7 +348,7 @@ abstract class RControllerAdminBase extends JControllerAdmin
 	 */
 	protected function getRedirectToListRoute($append = null)
 	{
-		$returnUrl = $this->input->get('return');
+		$returnUrl = $this->input->get('return', null, 'base64');
 
 		if ($returnUrl)
 		{


### PR DESCRIPTION
Fix error when JInput read return variable. It's will conflict with base64 special characters.
