### PR TITLE
RD-195 fix wrong call to icon checkin

### DIFF
--- a/libraries/redcore/toolbar/builder.php
+++ b/libraries/redcore/toolbar/builder.php
@@ -152,7 +152,7 @@ final class RToolbarBuilder
 	 */
 	public static function createCheckinButton($task, $class = '')
 	{
-		return new RToolbarButtonStandard('JTOOLBAR_CHECKIN', $task, $class, 'icon-checkin');
+		return new RToolbarButtonStandard('JTOOLBAR_CHECKIN', $task, $class, 'icon-check');
 	}
 
 	/**


### PR DESCRIPTION
Before the icon was not shown:

![wrongicon](https://f.cloud.github.com/assets/1375475/2043104/220cf2d6-89da-11e3-954e-99be0462b46d.png)

This is due to a wrong call to the icon class: http://fontawesome.io/3.2.1/icon/check/, the right is "icon-check" and not "icon-checkin".

Result after the pull:
![screen shot 2014-01-30 at 18 58 30](https://f.cloud.github.com/assets/1375475/2043115/3d931562-89da-11e3-9adc-39681457dd29.png)
