### PR TITLE
REDCORE-165: Fix uninstall error

### DIFF
--- a/install.php
+++ b/install.php
@@ -552,6 +552,8 @@ class Com_RedcoreInstallerScript
 	{
 		require_once JPATH_LIBRARIES . '/redcore/bootstrap.php';
 
+		RBootstrap::bootstrap();
+
 		// Avoid uninstalling redcore if there is a component using it
 		$manifest = $this->getManifest($parent);
 		$isRedcore = 'COM_REDCORE' === (string) $manifest->name;


### PR DESCRIPTION
Fix for uninstall error:

Fatal error: Class 'RComponentHelper' not found in ../administrator/components/com_redcore/install.php on line 561
