### PR TITLE
REDCORE-193 [imp] #comment replace confusing icons for publish / unpublish

### DIFF
--- a/libraries/redcore/html/rgrid.php
+++ b/libraries/redcore/html/rgrid.php
@@ -228,8 +228,8 @@ abstract class JHtmlRgrid
 			$prefix = array_key_exists('prefix', $options) ? $options['prefix'] : '';
 		}
 
-		$states = array(1 => array('unpublish', 'JPUBLISHED', 'JLIB_HTML_UNPUBLISH_ITEM', 'JPUBLISHED', false, 'plus-sign', 'plus-sign'),
-			0 => array('publish', 'JUNPUBLISHED', 'JLIB_HTML_PUBLISH_ITEM', 'JUNPUBLISHED', false, 'minus-sign', 'minus-sign'),
+		$states = array(1 => array('unpublish', 'JPUBLISHED', 'JLIB_HTML_UNPUBLISH_ITEM', 'JPUBLISHED', false, 'ok-sign  icon-green', 'ok-sign icon-green'),
+			0 => array('publish', 'JUNPUBLISHED', 'JLIB_HTML_PUBLISH_ITEM', 'JUNPUBLISHED', false, 'remove-sign  icon-red', 'remove-sign  icon-red'),
 			2 => array('unpublish', 'JARCHIVED', 'JLIB_HTML_UNPUBLISH_ITEM', 'JARCHIVED', false, 'hdd', 'hdd'),
 			-2 => array('publish', 'JTRASHED', 'JLIB_HTML_PUBLISH_ITEM', 'JTRASHED', false, 'trash', 'trash'));
 


### PR DESCRIPTION
Before:

![publish_icon-before](https://cloud.githubusercontent.com/assets/1119272/2872490/6f7c3eb8-d364-11e3-8b0f-59047c4757fd.png)

After:

![publish_icon-after](https://cloud.githubusercontent.com/assets/1119272/2872491/72ca8ef8-d364-11e3-99f2-0264211409e1.png)

It also adds `icon-green` & `icon-red` to be able to style it in different colors 
