### PR TITLE
REDCORE-224 Add Code Style checker ignores to external libraries

### DIFF
--- a/.travis/phpcs.php
+++ b/.travis/phpcs.php
@@ -30,7 +30,11 @@ $ignored = array(
 	REPO_BASE . '/component/admin/tables/*',
 	REPO_BASE . '/component/site/views/*/tmpl/*',
 	REPO_BASE . '/component/site/layouts/*',
-	REPO_BASE . '/libraries/redcore/api/*'
+	REPO_BASE . '/libraries/redcore/api/*',
+	REPO_BASE . '/libraries/redcore/layouts/webservice/*',
+	REPO_BASE . '/libraries/redcore/libraries/redcore/model/admin.php',
+	REPO_BASE . '/libraries/redcore/libraries/oauth/*',
+	REPO_BASE . '/libraries/redcore/libraries/oauth2/*'
 );
 
 // Build the options for the sniffer


### PR DESCRIPTION
This external libraries are not following our coding standards so I'm ignoring them. Otherwise the travis report is a long list of warnings that are not helpful.
