### PR TITLE
Loaded component specific language strings, leaving en-GB as common fallback in case backend is in another language

### DIFF
--- a/component/admin/views/config/view.html.php
+++ b/component/admin/views/config/view.html.php
@@ -64,12 +64,8 @@ class RedcoreViewConfig extends RedcoreHelpersView
 		$lang = JFactory::getLanguage();
 
 		// Load component language files
-		$lang->load($option, JPATH_ADMINISTRATOR, 'en-GB', true, false)
-		|| $lang->load($option, JPATH_ADMINISTRATOR . '/components/' . $option, 'en-GB', true, false)
-		|| $lang->load($option, JPATH_ADMINISTRATOR, null, true, false)
-		|| $lang->load($option, JPATH_ADMINISTRATOR . '/components/' . $option, null, true, false)
-		|| $lang->load($option, JPATH_ADMINISTRATOR, RTranslationHelper::getSiteLanguage(), true, true)
-		|| $lang->load($option, JPATH_ADMINISTRATOR . '/components/' . $option, RTranslationHelper::getSiteLanguage(), true, true);
+		$lang->load($option, JPATH_ADMINISTRATOR, 'en-GB', false, false)
+		|| $lang->load($option, JPATH_ADMINISTRATOR . '/components/' . $option, 'en-GB', false, false);
 
 		$this->form	= $model->getForm();
 		$this->component = $model->getComponent($option);


### PR DESCRIPTION
When switching the backend to a different (non en-GB) language, this PR makes sure that at least en-GB is used as a fallback, to avoid strings in the config like:

![image](https://cloud.githubusercontent.com/assets/1500978/5198587/96c0526a-7518-11e4-8cdf-65216174d62f.png)
