### PR TITLE
REDCORE-282 Maintain original resource order in ws documentation

### DIFF
--- a/libraries/redcore/api/hal/hal.php
+++ b/libraries/redcore/api/hal/hal.php
@@ -867,7 +867,14 @@ class RApiHalHal extends RApi
 	 */
 	public function sortResourcesByDisplayGroup($a, $b)
 	{
-		return strcmp($a["displayGroup"], $b["displayGroup"]);
+		$sort = strcmp($a["displayGroup"], $b["displayGroup"]);
+
+		if (!$sort)
+		{
+			return ($a['original_order'] < $b['original_order'] ? -1 : 1);
+		}
+
+		return $sort;
 	}
 
 	/**

--- a/libraries/redcore/layouts/webservice/documentationoperation.php
+++ b/libraries/redcore/layouts/webservice/documentationoperation.php
@@ -37,13 +37,26 @@ $resources = $view->loadResourceFromConfiguration($operationXml);
 				<p><?php echo $operationXml->resources->description ?></p>
 			<?php endif; ?>
 			<?php foreach ($resources as $resourceGroupName => $resourceGroup) : ?>
-				<?php usort($resourceGroup, array($view, "sortResourcesByDisplayGroup"));
-				$currentDisplayGroup = '--'; ?>
+				<?php
+					$i = 0;
+
+					foreach ($resourceGroup as $resName => $res)
+					{
+						$resourceGroup[$resName]['original_order'] = $i;
+						$i++;
+					}
+
+					usort($resourceGroup, array($view, "sortResourcesByDisplayGroup"));
+					$currentDisplayGroup = '--';
+				?>
 				<h4><?php echo $resourceGroupName == 'rcwsGlobal' ? JText::_('JDEFAULT') : ucfirst($resourceGroupName); ?>
 					 <?php echo JText::_('LIB_REDCORE_API_HAL_WEBSERVICE_DOCUMENTATION_RESOURCES'); ?></h4>
 
 				<div class="container-fluid">
-					<?php foreach ($resourceGroup as $resource) : ?>
+					<?php
+						foreach ($resourceGroup as $resource) :
+							unset($resource['original_order']);
+					?>
 						<?php if ($currentDisplayGroup != $resource['displayGroup']) : ?>
 							<?php if ($currentDisplayGroup != '--') : ?>
 								</table>


### PR DESCRIPTION
After digging a bit in usort, there's no way for it - or any other array sort function - to keep the original order, because of a recent upgrade in PHP 4.1
So, and since this is just for documentation, I decided to populate the original order, but maintaining the displayGroup as the first criteria for grouping the resources.
