### PR TITLE
Add param "option" for RTable::getAutoInstance

### DIFF
--- a/libraries/redcore/table/table.php
+++ b/libraries/redcore/table/table.php
@@ -730,14 +730,19 @@ class RTable extends JTable
 	 * @param   string  $name    The table name
 	 * @param   mixed   $client  The client. null = auto, 1 = admin, 0 = frontend
 	 * @param   array   $config  An optional array of configuration
+	 * @param   string  $option  Component name, use for call table from another extension
 	 *
 	 * @return  RTable  The table
 	 *
 	 * @throws  InvalidArgumentException
 	 */
-	public static function getAutoInstance($name, $client = null, array $config = array())
+	public static function getAutoInstance($name, $client = null, array $config = array(), $option = 'auto')
 	{
-		$option = JFactory::getApplication()->input->getString('option', '');
+		if ($option === 'auto')
+		{
+			$option = JFactory::getApplication()->input->getString('option', '');
+		}
+
 		$componentName = ucfirst(strtolower(substr($option, 4)));
 		$prefix = $componentName . 'Table';
 
@@ -782,12 +787,13 @@ class RTable extends JTable
 	 *
 	 * @param   string  $name    The table name
 	 * @param   array   $config  An optional array of configuration
+	 * @param   string  $option  Component name, use for call table from another extension
 	 *
 	 * @return  RTable  The table
 	 */
-	public static function getAdminInstance($name, array $config = array())
+	public static function getAdminInstance($name, array $config = array(), $option = 'auto')
 	{
-		return self::getAutoInstance($name, 1, $config);
+		return self::getAutoInstance($name, 1, $config, $option);
 	}
 
 	/**
@@ -795,12 +801,13 @@ class RTable extends JTable
 	 *
 	 * @param   string  $name    The table name
 	 * @param   array   $config  An optional array of configuration
+	 * @param   string  $option  Component name, use for call table from another extension
 	 *
 	 * @return  RTable  The table
 	 */
-	public static function getFrontInstance($name, array $config = array())
+	public static function getFrontInstance($name, array $config = array(), $option = 'auto')
 	{
-		return self::getAutoInstance($name, 0, $config);
+		return self::getAutoInstance($name, 0, $config, $option);
 	}
 
 	/**


### PR DESCRIPTION
Add this param "option" for allow 1 extension can getInstance a table from another extension. This option already have in RModel, I think RTable nice to have this too.

Ex: In redITEM view, can get an instance of RedsliderTableGallery by this line:
$redsliderGalleryTable = RTable::getAdminInstance('Gallery', array('ignore_request' => true), 'com_redslider');
