### PR TITLE
REDCORE-328 Added preprocessing function for fields in report

### DIFF
--- a/libraries/redcore/view/csv.php
+++ b/libraries/redcore/view/csv.php
@@ -89,7 +89,7 @@ abstract class RViewCsv extends JViewLegacy
 			{
 				if (property_exists($item, $name))
 				{
-					$csvLines[$i][$name] = $item->$name;
+					$csvLines[$i][$name] = $this->preprocess($item->$name);
 				}
 			}
 
@@ -125,6 +125,19 @@ abstract class RViewCsv extends JViewLegacy
 		fclose($stream);
 
 		JFactory::getApplication()->close();
+	}
+
+	/**
+	 * Preprocesses fields to be added
+	 *
+	 * @param   string  $field  The field value to be processed
+	 *
+	 * @return	string	The processed field value
+	 */
+	protected function preprocess($field)
+	{
+		// Function is meant to be overridden in other views.
+		return $field;
 	}
 
 	/**

--- a/libraries/redcore/view/csv.php
+++ b/libraries/redcore/view/csv.php
@@ -81,6 +81,9 @@ abstract class RViewCsv extends JViewLegacy
 		$csvLines[0] = $columns;
 		$i = 1;
 
+		// Check if the preprocessing method exists
+		$preprocessExists = method_exists($this, 'preprocess');
+
 		foreach ($items as $item)
 		{
 			$csvLines[$i] = array();
@@ -89,7 +92,7 @@ abstract class RViewCsv extends JViewLegacy
 			{
 				if (property_exists($item, $name))
 				{
-					$csvLines[$i][$name] = $this->preprocess($item->$name);
+					$csvLines[$i][$name] = $preprocessExists ? $this->preprocess($name, $item->$name) : $item->$name;
 				}
 			}
 
@@ -125,19 +128,6 @@ abstract class RViewCsv extends JViewLegacy
 		fclose($stream);
 
 		JFactory::getApplication()->close();
-	}
-
-	/**
-	 * Preprocesses fields to be added
-	 *
-	 * @param   string  $field  The field value to be processed
-	 *
-	 * @return	string	The processed field value
-	 */
-	protected function preprocess($field)
-	{
-		// Function is meant to be overridden in other views.
-		return $field;
 	}
 
 	/**


### PR DESCRIPTION
Function to be overridden in other classes. Used e.g. to replace the currency separator dynamically, since it's stored with just a `.` regardless of region.
Related to `RSTBT-1911`.