### PR TITLE
Rsbtb 2024 check for read item fix

### DIFF
--- a/libraries/redcore/api/hal/hal.php
+++ b/libraries/redcore/api/hal/hal.php
@@ -574,6 +574,7 @@ class RApiHalHal extends RApi
 		$itemObject = method_exists($model, $functionName) ? call_user_func_array(array(&$model, $functionName), $primaryKeys) : array();
 		$messagesAfter = JFactory::getApplication()->getMessageQueue();
 
+		// Check to see if we have the item or not since it might return default properties
 		if (count($messagesBefore) != count($messagesAfter))
 		{
 			foreach ($messagesAfter as $messageKey => $messageValue)

--- a/libraries/redcore/api/hal/hal.php
+++ b/libraries/redcore/api/hal/hal.php
@@ -570,15 +570,30 @@ class RApiHalHal extends RApi
 
 		// Getting single item
 		$functionName = RApiHalHelper::attributeToString($currentConfiguration, 'functionName', 'getItem');
+		$messagesBefore = JFactory::getApplication()->getMessageQueue();
 		$itemObject = method_exists($model, $functionName) ? call_user_func_array(array(&$model, $functionName), $primaryKeys) : array();
+		$messagesAfter = JFactory::getApplication()->getMessageQueue();
 
-		// Check to see if we have the item or not since it might return default properties
-		foreach ($primaryKeysFromFields as $primaryKey => $primaryKeyField)
+		if (count($messagesBefore) != count($messagesAfter))
 		{
-			if (!isset($itemObject->{$primaryKey}))
+			foreach ($messagesAfter as $messageKey => $messageValue)
 			{
-				$itemObject = null;
-				break;
+				$messageFound = false;
+
+				foreach ($messagesBefore as $key => $value)
+				{
+					if ($messageValue['type'] == $value['type'] && $messageValue['message'] == $value['message'])
+					{
+						$messageFound = true;
+						break;
+					}
+				}
+
+				if (!$messageFound && $messageValue['type'] == 'error')
+				{
+					$itemObject = null;
+					break;
+				}
 			}
 		}
 


### PR DESCRIPTION
needed because some models on read item returns instance of the object with a JRegistry params and tags, so it is not possible to distinct if the item is found or not. Previous attempt with primary keys is not always best option because model does not have to return primary key field in the object. This will check if the model have put error message when trying to get the item