### PR TITLE
REDCORE-350 fix Strict standards error calling statically a non static method

### DIFF
--- a/libraries/redcore/redcore.xml
+++ b/libraries/redcore/redcore.xml
@@ -8,7 +8,7 @@
     <authorUrl>www.redcomponent.com</authorUrl>
     <copyright>Copyright (C) 2008 - 2015 redCOMPONENT.com. All rights reserved.</copyright>
     <license>GNU General Public License version 2 or later, see LICENSE.</license>
-    <version>1.4.19</version>
+    <version>1.4.20</version>
     <description>redCORE Libraries</description>
 
     <files>

--- a/libraries/redcore/translation/content/helper.php
+++ b/libraries/redcore/translation/content/helper.php
@@ -46,7 +46,7 @@ final class RTranslationContentHelper
 	 *
 	 * @return  void
 	 */
-	public function saveUrlParams($field, &$fieldValue, &$allValues, $translationTable)
+	public static function saveUrlParams($field, &$fieldValue, &$allValues, $translationTable)
 	{
 		// Check for the extension specific 'request' entry.
 		if (!empty($allValues['request']) && is_array($allValues['request']))
@@ -70,7 +70,7 @@ final class RTranslationContentHelper
 	 *
 	 * @return  void
 	 */
-	public function saveMenuPath($field, &$fieldValue, &$allValues, $translationTable)
+	public static function saveMenuPath($field, &$fieldValue, &$allValues, $translationTable)
 	{
 		// If there is no alias or path field, just return true.
 		if (!array_key_exists('alias', $allValues) || !array_key_exists('path', $allValues))

--- a/modules/site/mod_redcore_language_switcher/mod_redcore_language_switcher.xml
+++ b/modules/site/mod_redcore_language_switcher/mod_redcore_language_switcher.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="module" version="2.5" client="site" method="upgrade">
 	<name>MOD_REDCORE_LANGUAGE_SWITCHER</name>
-	<version>1.4.19</version>
+	<version>1.4.20</version>
 	<creationDate>August 2014</creationDate>
 	<author>redCOMPONENT.com</author>
 	<authorEmail>email@redcomponent.com</authorEmail>

--- a/plugins/system/redcore/redcore.xml
+++ b/plugins/system/redcore/redcore.xml
@@ -7,7 +7,7 @@
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>email@redcomponent.com</authorEmail>
     <authorUrl>www.redcomponent.com</authorUrl>
-    <version>1.4.19</version>
+    <version>1.4.20</version>
     <description>PLG_SYSTEM_REDCORE_XML_DESCRIPTION</description>
 
     <files>

--- a/redcore.xml
+++ b/redcore.xml
@@ -7,10 +7,10 @@
     <authorUrl>www.redcomponent.com</authorUrl>
     <copyright>Copyright (C) 2008 - 2015 redCOMPONENT.com. All rights reserved.</copyright>
     <license>GNU General Public License version 2 or later, see LICENSE.</license>
-    <version>1.4.19</version>
+    <version>1.4.20</version>
     <description>COM_REDCORE_DESC</description>
     <scriptfile>install.php</scriptfile>
-    <redcore version="1.4.19" defaultFramework="bootstrap3" />
+    <redcore version="1.4.20" defaultFramework="bootstrap3" />
 
     <install folder="component/admin">
         <sql>


### PR DESCRIPTION
This methods should be static to avoid this error:

```
( ! ) Strict standards: call_user_func_array() expects parameter 1 to be a valid callback, non-static method RTranslationContentHelper::saveUrlParams() should not be called statically in /var/www/translate/administrator/components/com_redcore/models/translation.php on line 253
```