### PR TITLE
[fix] a package cannot install 2 components with redCORE as dependency

### DIFF
--- a/install.php
+++ b/install.php
@@ -157,17 +157,20 @@ class Com_RedcoreInstallerScript
 					return false;
 				}
 
-				$searchPaths = array(
-					// Discover install
-					JPATH_LIBRARIES . '/redcore/component',
-					// Install
-					dirname(__FILE__) . '/redCORE/libraries/redcore/component',
-					dirname(__FILE__) . '/libraries/redcore/component',
-				);
-
-				if ($componentHelper = JPath::find($searchPaths, 'helper.php'))
+				if (!class_exists('RComponentHelper'))
 				{
-					require_once $componentHelper;
+					$searchPaths = array(
+						// Discover install
+						JPATH_LIBRARIES . '/redcore/component',
+						// Install
+						dirname(__FILE__) . '/redCORE/libraries/redcore/component',
+						dirname(__FILE__) . '/libraries/redcore/component',
+					);
+
+					if ($componentHelper = JPath::find($searchPaths, 'helper.php'))
+					{
+						require_once $componentHelper;
+					}
 				}
 			}
 


### PR DESCRIPTION
There is a bug when installing a package that contains 2 components that depend on redCORE (e.g. to prevent it from being uninstalled when any of them are still there).

On the first pass `RComponentHelper` will be loaded from the install folder but in the second pass (when installing the second component) the file will be found already installed so require_once isn't enough to ensure that it's not loaded twice.