### PR TITLE
[imp] allow to override doDelete on child classes

### DIFF
--- a/libraries/redcore/table/table.php
+++ b/libraries/redcore/table/table.php
@@ -725,7 +725,7 @@ class RTable extends JTable
 	 *
 	 * @return  boolean  Deleted successfuly?
 	 */
-	private function doDelete($pk = null)
+	protected function doDelete($pk = null)
 	{
 		// Initialise variables.
 		$k = $this->_tbl_key;


### PR DESCRIPTION
I think it doesn't make a lot of sense that a method of a class that is really abstract cannot be overriden in child classes. 

Of course you can bypass if by overriding `delete()` method in your child class and calling another function from there (like `doMyDelete()`) but it just makes things harder.