### PR TITLE
REDCORE-269 standarise api tests names

### DIFF
--- a/tests/api/administrator.contact.1.0.0.Cest.php
+++ b/tests/api/administrator.contact.1.0.0.Cest.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-class ContactsCest
+class AdministratorContacts1Cest
 {
 	/**
 	 * The new contact id
@@ -16,20 +16,46 @@ class ContactsCest
 	 */
 	private $contactID = 0;
 
+	/**
+	 * The new contact name
+	 *
+	 * @var int
+	 */
 	private $contactName = '';
 
-
+	/**
+	 * Set up the contact stub
+	 */
 	public function __construct()
 	{
 		$this->contactName = 'contact' . rand(0,1000);
 	}
 
+	public function WebserviceIsAvailable(ApiTester $I)
+	{
+		$I->wantTo("check the availability of the webservice");
+		$I->amHttpAuthenticated('admin', 'admin');
+		$I->sendGET('index.php',
+		            [
+			            'option' => 'contact',
+			            'api' => 'Hal',
+			            'webserviceClient' => 'administrator',
+		            ]
+		);
+		$I->seeResponseCodeIs(200);
+		$I->seeResponseIsJson();
+		$I->seeHttpHeader('Webservice-name', 'contact');
+		$I->seeHttpHeader('Webservice-version', '1.0.0');
+	}
+
 	/**
 	 * Create a new contact using Contacts Webservices API
 	 *
+	 * @depends WebserviceIsAvailable
+	 *
 	 * @param ApiTester $I
 	 */
-	public function administratorCreateContact(ApiTester $I)
+	public function create(ApiTester $I)
 	{
 		$I->wantTo('POST via webservices a new Contact in com_contacts');
 		$I->amHttpAuthenticated('admin', 'admin');
@@ -51,11 +77,11 @@ class ContactsCest
 	/**
 	 * Get a contact using Contact Webservices API
 	 *
-	 * @depends administratorCreateContact
+	 * @depends create
 	 *
 	 * @param ApiTester $I
 	 */
-	public function administratorGetContact(ApiTester $I)
+	public function readItem(ApiTester $I)
 	{
 		$I->wantTo("GET via webservices an existing Contact");
 		$I->amHttpAuthenticated('admin', 'admin');
@@ -72,11 +98,11 @@ class ContactsCest
 	/**
 	 * Update an existing contact using Contacts Webservices API
 	 *
-	 * @depends administratorGetContact
+	 * @depends readItem
 	 *
 	 * @param ApiTester $I
 	 */
-	public function administratorUpdateContact(ApiTester $I)
+	public function update(ApiTester $I)
 	{
 		$I->wantTo('Update via webservices a new Contact in com_contacts using PUT');
 		$I->amHttpAuthenticated('admin', 'admin');
@@ -106,11 +132,11 @@ class ContactsCest
 	/**
 	 * Delete an existing contact using Contacts Webservices API
 	 *
-	 * @depends administratorUpdateContact
+	 * @depends update
 	 *
 	 * @param ApiTester $I
 	 */
-	public function administratorDeleteContact(ApiTester $I)
+	public function delete(ApiTester $I)
 	{
 
 		$I->wantTo('Delete via webservices a new Contact in com_contacts using DELETE');
@@ -142,7 +168,7 @@ class ContactsCest
 	 *
 	 * @param ApiTester $I
 	 */
-	public function administratorCreateContactWithoutClient(ApiTester $I)
+	public function createWithoutClient(ApiTester $I)
 	{
 		$I->wantTo("POST via webservices a new Contact in com_contacts without specifying client in the request params");
 		$I->amHttpAuthenticated('admin', 'admin');
@@ -167,7 +193,7 @@ class ContactsCest
 	 *
 	 * @param ApiTester $I
 	 */
-	public function administratorGetContactWithoutClient(ApiTester $I)
+	public function readWithoutClient(ApiTester $I)
 	{
 		$I->wantTo('GET via webservices an existing Contact without specify Client in the request');
 		$I->amHttpAuthenticated('admin', 'admin');


### PR DESCRIPTION
I'm updating Contacts test name to match the standard created at redSHOPB2B. This way tests have the  same name as the webservice.

Also, methods have been renamed to a more simple way.