### PR TITLE
JPagination link href issue in frontend with getListFooter

### DIFF
--- a/libraries/redcore/layouts/pagination/link.php
+++ b/libraries/redcore/layouts/pagination/link.php
@@ -68,12 +68,20 @@ if($displayData['active'])
 		$title = ' title="' . $item->text . '" ';
 	}
 
-	$onClick = "document."
-		. $item->formName
-		. "."
-		. $item->prefix
-		. $limit
-		. "; Joomla.submitform(document.forms['" . $item->formName . "'].task.value, document.forms['" . $item->formName . "']);return false;";
+	$onClick = '';
+	$href    = trim($item->link);
+
+	// Still using javascript approach in backend
+	if (JFactory::getApplication()->isAdmin())
+	{
+		$onClick = 'onclick="document.'
+				. $item->formName
+				. '.'
+				. $item->prefix
+				. $limit
+				. '; Joomla.submitform(document.forms[\'' . $item->formName . '\'].task.value, document.forms[\'' . $item->formName . '\']);return false;"';
+		$href    = '#';
+	}
 }
 else
 {
@@ -82,7 +90,12 @@ else
 ?>
 <?php if ($displayData['active']) : ?>
 	<li>
-		<a class="<?php echo implode(' ', $cssClasses); ?>" <?php echo $title; ?> href="#" onclick="<?php echo $onClick; ?>">
+		<a
+			<?php echo !empty($cssClasses) ? 'class="' . implode(' ', $cssClasses) . '"' : ''; ?>
+			<?php echo $title; ?>
+			<?php echo $onClick; ?>
+			href="<?php echo $href; ?>"
+		>
 			<?php echo $display; ?>
 		</a>
 	</li>


### PR DESCRIPTION
Found the issue with Javascript approach in frontend when using `getListFooter` function. 
Fixed the same issue in Joomla core too https://github.com/joomla/joomla-cms/pull/7319

### Problem
When using `getListFooter` in frontend, having issue in pagination link because of Javascript.

#### For Example:
If we use
```
echo $this->pagination->getListFooter();
```
_Note: Layout or pagination file should not be overrided_

### How to reproduce
To reproduce this issue can manually use above function in code or if you are using `JPagination` in your component you may check there. 

_There are many other ways to fix it by overriding `JPagination` class and `JLayout` but I think this should be fix in core too._
