### PR TITLE
Avoid doing snapshot of allow_failure builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ script:
 - mv tests/acceptance.suite.dist.yml tests/acceptance.suite.yml
 - mv tests/api.suite.dist.yml tests/api.suite.yml
 - vendor/bin/robo run:tests
-- vendor/bin/robo send:codeception-output-to-slack C02L0SE5E xoxp-2309442657-4789197868-4789233706-68cec7
+- if [ $TRAVIS_PHP_VERSION == 5.5 ]; then vendor/bin/robo send:codeception-output-to-slack C02L0SE5E xoxp-2309442657-4789197868-4789233706-68cec7; fi
 notifications:
   slack:
     secure: AeKLAsle7sQ3lGpXeNk0ePovlnf0QTggiKhHuvEH78TD5aN8OjYEqbLBhFWWcejn4hHWHOeR9pUv0wqClEGirMioWI5noQvE6D6bV9oBrAhx2FKLVxCA3YN23i+ehNpk3+FpVhkmagigiEnPZqqFcqFw5x276GVZTC8etNmzs/w=


### PR DESCRIPTION
right now redCORE in PHP7 is not working. But being PHP7 not yet stable we don't need to send snapshots of the failures. With this modification I'm making travis to not send snapshots on builds other than 5.5