### PR TITLE
[fix] component detection does not work on Windows machines

### DIFF
--- a/libraries/redcore/layout/file.php
+++ b/libraries/redcore/layout/file.php
@@ -276,12 +276,7 @@ class RLayoutFile extends RLayoutBase
 				break;
 
 			case 'auto':
-				if (defined('JPATH_COMPONENT'))
-				{
-					$parts = explode('/', JPATH_COMPONENT);
-					$component = end($parts);
-				}
-
+				$component = JApplicationHelper::getComponentName();
 				break;
 
 			default:


### PR DESCRIPTION
On windows machines the function that tries to detect automatically the active component does not work because paths use \ instead of /.

I have replaced it with `JApplicationHelper::getComponentName();` which should save us work.