### PR TITLE
RSBTB-2408 #comment Fixed wrong redirection when use subfolders in a server

### DIFF
--- a/libraries/redcore/browser/browser.php
+++ b/libraries/redcore/browser/browser.php
@@ -84,10 +84,11 @@ class RBrowser
 		// We are removing format because of default value is csv if present and if not set
 		// and we are never going to remember csv page in a browser history anyway
 		$uri->delVar('format');
-		$query = $router->parse($uri);
-		$uri = 'index.php?' . Juri::getInstance()->buildQuery($query);
+		$parseUri = clone $uri;
+		$query = $router->parse($parseUri);
+		$url = 'index.php?' . Juri::getInstance()->buildQuery($query);
 
-		$this->history->enqueue($uri, $duplicateLast);
+		$this->history->enqueue($url, $duplicateLast);
 	}
 
 	/**


### PR DESCRIPTION
$router->parse change $uri and crop url 'path' value for current page link, so it must be clone before execution.