### PR TITLE
Gulp build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,11 @@ robo.phar
 # LESS Transpiler
 npm-debug.log
 
+# Build config
+gulp-config.json
+node_modules
+releases
+
 # Test related files
 tests/acceptance.suite.yml
 tests/functional.suite.yml

--- a/composer.lock
+++ b/composer.lock
@@ -511,12 +511,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-projects/joomla-browser.git",
-                "reference": "650962ebb7fb2ff25b09b71a71147e28bb8939f9"
+                "reference": "6070485e9d7680f83f9e3ed09700cebf04b2bfe9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-projects/joomla-browser/zipball/650962ebb7fb2ff25b09b71a71147e28bb8939f9",
-                "reference": "650962ebb7fb2ff25b09b71a71147e28bb8939f9",
+                "url": "https://api.github.com/repos/joomla-projects/joomla-browser/zipball/6070485e9d7680f83f9e3ed09700cebf04b2bfe9",
+                "reference": "6070485e9d7680f83f9e3ed09700cebf04b2bfe9",
                 "shasum": ""
             },
             "require": {
@@ -554,7 +554,7 @@
                 "acceptance testing",
                 "joomla"
             ],
-            "time": "2015-09-28 14:59:15"
+            "time": "2015-09-22 11:29:55"
         },
         {
             "name": "pdepend/pdepend",

--- a/gulp-config.json.dist
+++ b/gulp-config.json.dist
@@ -1,0 +1,6 @@
+{
+	"wwwDir"           : "/var/www/joomla-cms",
+	"browserConfig" : {
+		"proxy" : "localhost"
+	}
+}

--- a/gulp-extensions.json
+++ b/gulp-extensions.json
@@ -1,0 +1,12 @@
+{
+	"components" : ["redcore"],
+	"libraries"  : ["redcore"],
+	"media"      : ["redcore"],
+	"modules"    : {
+		"frontend"       : ["redcore_langswitcher"]
+	},
+	"plugins"    : {
+		"redpayment"     : ["paypal"],
+		"system"         : ["redcore", "mvcoverride"]
+	}
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,47 @@
+var gulp = require('gulp');
+
+var extension = require('./package.json');
+
+var requireDir = require('require-dir');
+var zip        = require('gulp-zip');
+
+var config    = require('./gulp-config.json');
+
+var jgulp   = requireDir('./node_modules/joomla-gulp', {recurse: true});
+var redcore = requireDir('./node_modules/gulp-redcore', {recurse: true});
+
+// Override of the release script
+gulp.task('release', function () {
+	return gulp.src([
+			'./**/*',
+			'./**/.gitkeep',
+			"!./**/bower.json",
+			"!./**/scss/**",
+			"!./**/less/**",
+			"!./**/build.*",
+			"!./**/build/**",
+			"!./**/*.md",
+			"!./**/docs/**",
+			"!./**/joomla-gulp/**",
+			"!./**/jgulp/**",
+			"!./**/gulp**",
+			"!./**/gulp**/**",
+			"!./**/gulpfile.js",
+			"!./**/node_modules/**",
+			"!./**/node_modules/**/.*",
+			"!./**/package.json",
+			"!./**/releases/**",
+			"!./**/releases/**/.*",
+			"!./src/**",
+			'!./**/sample/**',
+			'!./**/sample/.*',
+			'!./**/tests/**',
+			'!./**/tests/.*',
+			"!./**/*.sublime-*",
+			"!./**/*.sh",
+			"!./**/composer.json",
+			"!./**/phpunit*.xml"
+		])
+		.pipe(zip(extension.name + '-' + extension.version + '.zip'))
+		.pipe(gulp.dest('releases'));
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "redCORE",
+  "version": "1.6.1",
+  "description": "Rapid application development layer for Joomla!",
+  "main": "gulpfile.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "browser-sync": "^2.9.6",
+    "del": "^2.0.2",
+    "gulp": "^3.9.0",
+    "gulp-less": "^3.0.3",
+    "gulp-minify-css": "^1.2.1",
+    "gulp-redcore": "0.0.1",
+    "gulp-rename": "^1.2.2",
+    "gulp-uglify": "^1.4.1",
+    "gulp-zip": "^3.0.2",
+    "joomla-gulp": "^1.1.1",
+    "require-dir": "^0.3.0"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:redCOMPONENT-COM/redCORE.git"
+  },
+  "bugs": {
+    "url": "https://github.com/redCOMPONENT-COM/redCORE/issues"
+  },
+  "keywords": [
+    "rad",
+    "joomla",
+    "library"
+  ],
+  "author": "redCOMPONENT <email@redcomponent.com>",
+  "license": "GPL-2.0"
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "gulp": "^3.9.0",
     "gulp-less": "^3.0.3",
     "gulp-minify-css": "^1.2.1",
-    "gulp-redcore": "0.0.1",
+    "gulp-redcore": "0.0.3",
     "gulp-rename": "^1.2.2",
     "gulp-uglify": "^1.4.1",
     "gulp-zip": "^3.0.2",


### PR DESCRIPTION
This integrates the joomla-gulp system with redCORE.

To speed things I have used a self hosted repo https://github.com/phproberto/gulp-redcore to store the redcore gulp scripts so they can be reused in any subproject that uses redCORE with:

`npm install gulp-redcore`

Then add the redcore extensions to the list of extensions of the project and system is ready.