### PR TITLE
Changed jQuery migrate load order to make sure jQuery scripts load to gether at the top of the document

### DIFF
--- a/libraries/redcore/html/rjquery.php
+++ b/libraries/redcore/html/rjquery.php
@@ -152,6 +152,8 @@ abstract class JHtmlRjquery
 	 */
 	public static function framework()
 	{
+		$doc = JFactory::getDocument();
+
 		// Only load once
 		if (!empty(static::$loaded[__METHOD__]))
 		{
@@ -160,11 +162,18 @@ abstract class JHtmlRjquery
 
 		$isAdmin = JFactory::getApplication()->isAdmin();
 
+		// Load jQuery Migrate in administration, or if it's frontend site and it has been asked via plugin parameters
+		if ($isAdmin || (!$isAdmin && RBootstrap::$loadFrontendjQueryMigrate))
+		{
+			$jqueryMigrate = array(
+				JUri::root(true) . '/media/redcore/js/lib/jquery-migrate.min.js' => array('mime' => 'text/javascript', 'defer' => '', 'async' => '')
+			);
+			$doc->_scripts = array_merge($jqueryMigrate, $doc->_scripts);
+		}
+
 		// Load jQuery in administration, or if it's frontend site and it has been asked via plugin parameters
 		if ($isAdmin || (!$isAdmin && RBootstrap::$loadFrontendjQuery))
 		{
-			$doc = JFactory::getDocument();
-
 			$jqueryLib = array(
 				JUri::root(true) . '/media/redcore/js/lib/jquery.min.js' => array('mime' => 'text/javascript', 'defer' => '', 'async' => '')
 			);
@@ -178,12 +187,6 @@ abstract class JHtmlRjquery
 		elseif (!$isAdmin && !RBootstrap::$loadFrontendjQuery && !version_compare(JVERSION, '3.0', '<'))
 		{
 			JHtml::_('jquery.framework');
-		}
-
-		// Load jQuery Migrate in administration, or if it's frontend site and it has been asked via plugin parameters
-		if ($isAdmin || (!$isAdmin && RBootstrap::$loadFrontendjQueryMigrate))
-		{
-			RHelperAsset::load('lib/jquery-migrate.min.js', self::EXTENSION);
 		}
 
 		static::$loaded[__METHOD__] = true;

--- a/libraries/redcore/joomla/form/field.php
+++ b/libraries/redcore/joomla/form/field.php
@@ -921,4 +921,38 @@ abstract class JFormField
 
 		return RLayoutHelper::render($this->renderLayout, array('input' => $this->getInput(), 'label' => $this->getLabel(), 'options' => $options));
 	}
+
+	/**
+	 * Method to get the data to be passed to the layout for rendering.
+	 *
+	 * @return  array
+	 *
+	 * @since 3.5
+	 */
+	protected function getInputLayoutData()
+	{
+		$alt = preg_replace('/[^a-zA-Z0-9_\-]/', '_', $this->fieldname);
+		return array(
+			'autocomplete' => $this->autocomplete,
+			'autofocus' => $this->autofocus,
+			'classes' => explode(' ', $this->class),
+			'disabled' => $this->disabled,
+			'group' => $this->group,
+			'hidden' => $this->hidden,
+			'hint' => $this->translateHint ? JText::alt($this->hint, $alt) : $this->hint,
+			'id' => $this->id,
+			'multiple' => $this->multiple,
+			'name' => $this->name,
+			'onchange' => $this->onchange,
+			'onclick' => $this->onclick,
+			'pattern' => $this->pattern,
+			'readonly' => $this->readonly,
+			'repeat' => $this->repeat,
+			'required' => $this->required,
+			'size' => $this->size,
+			'spellcheck' => $this->spellcheck,
+			'validate' => $this->validate,
+			'value' => $this->value
+		);
+	}
 }


### PR DESCRIPTION
This is actually just a quick fix for preventing Akeeba from clashing with redCORE.
However, we should review the way these scripts are being loaded.