### PR TITLE
Automatic ajax tokens for childlist field + base system for new fields

### DIFF
--- a/libraries/redcore/bootstrap.php
+++ b/libraries/redcore/bootstrap.php
@@ -131,6 +131,7 @@ class RBootstrap
 			RLoader::setup();
 
 			// Make available the redCORE fields
+			JFormHelper::addFieldPath(JPATH_REDCORE . '/form/field');
 			JFormHelper::addFieldPath(JPATH_REDCORE . '/form/fields');
 
 			// Make available the redCORE form rules

--- a/libraries/redcore/form/field/childlist.php
+++ b/libraries/redcore/form/field/childlist.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * @package     Redcore
+ * @subpackage  Field
+ *
+ * @copyright   Copyright (C) 2008 - 2015 redCOMPONENT.com. All rights reserved.
+ * @license     GNU General Public License version 2 or later, see LICENSE.
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+JFormHelper::loadFieldClass('rlist');
+
+/**
+ * Field a list dependent
+ *
+ * @since  1.7
+ */
+class RFormFieldChildlist extends JFormFieldRlist
+{
+	/**
+	 * The form field type.
+	 *
+	 * @var    string
+	 */
+	public $type = 'Childlist';
+
+	/**
+	 * Options for the ajaxfield script
+	 *
+	 * @var  array
+	 */
+	public $ajaxchildOptions = array(
+		'formSelector'   => '#adminForm',
+		'parentSelector' => '.js-parent-field',
+		'parentVarName'  => null,
+		'parentOnChange' => true,
+		'childSelector'  => null,
+		'ajaxUrl'        => null
+	);
+
+	/**
+	 * Layout to render
+	 *
+	 * @var  string
+	 */
+	protected $layout = 'redcore.field.childlist';
+
+	/**
+	 * Method to get the field input markup for a generic list.
+	 * Use the multiple attribute to enable multiselect.
+	 *
+	 * @return  string  The field input markup.
+	 */
+	protected function getInput()
+	{
+		// Receive ajax URL
+		$ajaxUrl = isset($this->element['url']) ? (string) $this->element['url'] : null;
+
+		if ($ajaxUrl)
+		{
+			$siteUrl = JUri::root();
+			$adminUrl = $siteUrl . 'administrator';
+
+			$this->ajaxchildOptions['ajaxUrl'] = str_replace(
+				array('{admin}', '{backend}', '{site}', '{frontend}'),
+				array($adminUrl, $adminUrl, $siteUrl, $siteUrl),
+				$ajaxUrl
+			);
+
+			// Automatically attach a token
+			$this->ajaxchildOptions['ajaxUrl'] .= '&' . JSession::getFormToken() . '=1';
+		}
+
+		// Receive child field selector
+		$childSelector = isset($this->element['child_selector']) ? (string) $this->element['child_selector'] : null;
+
+		if ($childSelector)
+		{
+			$this->ajaxchildOptions['childSelector'] = $childSelector;
+		}
+
+		// Receive parent field selector
+		$parentSelector = isset($this->element['parent_selector']) ? (string) $this->element['parent_selector'] : null;
+
+		if ($parentSelector)
+		{
+			$this->ajaxchildOptions['parentSelector'] = $parentSelector;
+		}
+
+		// Receive parent request var
+		$parentVarName = isset($this->element['parent_varname']) ? (string) $this->element['parent_varname'] : null;
+
+		if ($parentVarName)
+		{
+			$this->ajaxchildOptions['parentVarName'] = $parentVarName;
+		}
+
+		return parent::getInput();
+	}
+}

--- a/libraries/redcore/form/fields/rchildlist.php
+++ b/libraries/redcore/form/fields/rchildlist.php
@@ -9,95 +9,21 @@
 
 defined('JPATH_PLATFORM') or die;
 
-JFormHelper::loadFieldClass('rlist');
-
 /**
  * Field a list dependent
  *
  * @package     Redcore
  * @subpackage  Field
  * @since       1.0
+ *
+ * @deprecated  1.7  Use RFormFieldChildlist
  */
-class JFormFieldRchildlist extends JFormFieldRlist
+class JFormFieldRchildlist extends RFormFieldChildlist
 {
-	/**
-	 * The form field type.
-	 *
-	 * @var    string
-	 * @since  1.0
-	 */
-	public $type = 'Rchildlist';
-
-	/**
-	 * Options for the ajaxfield script
-	 *
-	 * @var  array
-	 */
-	public $ajaxchildOptions = array(
-		'formSelector'   => '#adminForm',
-		'parentSelector' => '.js-parent-field',
-		'parentVarName'  => null,
-		'parentOnChange' => true,
-		'childSelector'  => null,
-		'ajaxUrl'        => null
-	);
-
 	/**
 	 * Layout to render
 	 *
 	 * @var  string
 	 */
 	protected $layout = 'fields.rchildlist';
-
-	/**
-	 * Method to get the field input markup for a generic list.
-	 * Use the multiple attribute to enable multiselect.
-	 *
-	 * @return  string  The field input markup.
-	 *
-	 * @since   1.0
-	 */
-	protected function getInput()
-	{
-		// Receive ajax URL
-		$ajaxUrl = isset($this->element['url']) ? (string) $this->element['url'] : null;
-
-		if ($ajaxUrl)
-		{
-			$siteUrl = JUri::root();
-			$adminUrl = $siteUrl . 'administrator';
-
-			$this->ajaxchildOptions['ajaxUrl'] = str_replace(
-				array('{admin}', '{backend}', '{site}', '{frontend}'),
-				array($adminUrl, $adminUrl, $siteUrl, $siteUrl),
-				$ajaxUrl
-			);
-		}
-
-		// Receive child field selector
-		$childSelector = isset($this->element['child_selector']) ? (string) $this->element['child_selector'] : null;
-
-		if ($childSelector)
-		{
-			$this->ajaxchildOptions['childSelector'] = $childSelector;
-		}
-
-		// Receive parent field selector
-		$parentSelector = isset($this->element['parent_selector']) ? (string) $this->element['parent_selector'] : null;
-
-		if ($parentSelector)
-		{
-			$this->ajaxchildOptions['parentSelector'] = $parentSelector;
-		}
-
-		// Receive parent request var
-		$parentVarName = isset($this->element['parent_varname']) ? (string) $this->element['parent_varname'] : null;
-
-		if ($parentVarName)
-		{
-			$this->ajaxchildOptions['parentVarName'] = $parentVarName;
-		}
-
-		return parent::getInput();
-	}
 }

--- a/libraries/redcore/layouts/fields/rchildlist.php
+++ b/libraries/redcore/layouts/fields/rchildlist.php
@@ -9,17 +9,5 @@
 
 defined('JPATH_REDCORE') or die;
 
-$data = (object) $displayData;
-
-$options = !empty($data->field->ajaxchildOptions) ? $data->field->ajaxchildOptions : array();
-
-// We won't load anything if it's not going to work
-if (!empty($options['ajaxUrl']))
-{
-	$options['childSelector'] = isset($options['childSelector']) ? $options['childSelector'] : '.js-childlist-child';
-
-	JHtml::_('rjquery.childlist', $options['childSelector'], $options);
-}
-
-// Render the standard select
-echo RLayoutHelper::render('fields.rlist', $data);
+// This layout is deprecated and here only for B/C
+echo RLayoutHelper::render('redcore.field.childlist', $displayData);

--- a/libraries/redcore/layouts/fields/rlist.php
+++ b/libraries/redcore/layouts/fields/rlist.php
@@ -9,53 +9,5 @@
 
 defined('JPATH_REDCORE') or die;
 
-$data = (object) $displayData;
-
-$attributes = array();
-
-$attributes['id']            = $data->id;
-$attributes['class']         = $data->element['class'] ? (string) $data->element['class'] : null;
-$attributes['size']          = $data->element['size'] ? (int) $data->element['size'] : null;
-$attributes['multiple']      = $data->multiple ? 'multiple' : null;
-$attributes['required']      = $data->required ? 'required' : null;
-$attributes['aria-required'] = $data->required ? 'true' : null;
-$attributes['onchange']      = $data->element['onchange'] ? (string) $data->element['onchange'] : null;
-
-if ((string) $data->element['readonly'] == 'true' || (string) $data->element['disabled'] == 'true')
-{
-	$attributes['disabled'] = 'disabled';
-}
-
-$renderedAttributes = null;
-
-if ($attributes)
-{
-	foreach ($attributes as $attribute => $value)
-	{
-		if (null !== $value)
-		{
-			$renderedAttributes .= ' ' . $attribute . '="' . (string) $value . '"';
-		}
-	}
-}
-
-$readOnly = ((string) $data->element['readonly'] == 'true');
-
-// If it's readonly the select will have no name
-$selectName = $readOnly ? '' : $data->name;
-?>
-
-<select name="<?php echo $selectName; ?>" <?php echo $renderedAttributes; ?>>
-	<?php if ($data->options) : ?>
-		<?php foreach ($data->options as $option) :?>
-				<option
-					value="<?php echo $option->value; ?>"
-					<?php if ((is_array($data->value) && in_array($option->value, $data->value)) || (!is_array($data->value) && $option->value == $data->value)):
-						echo 'selected="selected"';
-					endif; ?>><?php echo $option->text; ?></option>
-		<?php endforeach; ?>
-	<?php endif; ?>
-</select>
-<?php if ((string) $data->element['readonly'] == 'true') : ?>
-	<input type="hidden" name="<?php echo $data->name; ?>" value="<?php echo $data->value; ?>"/>
-<?php endif;
+// This layout is deprecated and here only for B/C
+echo RLayoutHelper::render('redcore.field.list', $displayData);

--- a/libraries/redcore/layouts/redcore/field/childlist.php
+++ b/libraries/redcore/layouts/redcore/field/childlist.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @package     Redcore
+ * @subpackage  Layouts
+ *
+ * @copyright   Copyright (C) 2008 - 2015 redCOMPONENT.com. All rights reserved.
+ * @license     GNU General Public License version 2 or later, see LICENSE.
+ */
+
+defined('JPATH_REDCORE') or die;
+
+$data = (object) $displayData;
+
+$options = !empty($data->field->ajaxchildOptions) ? $data->field->ajaxchildOptions : array();
+
+// We won't load anything if it's not going to work
+if (!empty($options['ajaxUrl']))
+{
+	$options['childSelector'] = isset($options['childSelector']) ? $options['childSelector'] : '.js-childlist-child';
+
+	JHtml::_('rjquery.childlist', $options['childSelector'], $options);
+}
+
+// Render the standard select
+echo RLayoutHelper::render('redcore.field.list', $data);

--- a/libraries/redcore/layouts/redcore/field/list.php
+++ b/libraries/redcore/layouts/redcore/field/list.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * @package     Redcore
+ * @subpackage  Layouts
+ *
+ * @copyright   Copyright (C) 2008 - 2015 redCOMPONENT.com. All rights reserved.
+ * @license     GNU General Public License version 2 or later, see LICENSE.
+ */
+
+defined('JPATH_REDCORE') or die;
+
+$data = (object) $displayData;
+
+$attributes = array();
+
+$attributes['id']            = $data->id;
+$attributes['class']         = $data->element['class'] ? (string) $data->element['class'] : null;
+$attributes['size']          = $data->element['size'] ? (int) $data->element['size'] : null;
+$attributes['multiple']      = $data->multiple ? 'multiple' : null;
+$attributes['required']      = $data->required ? 'required' : null;
+$attributes['aria-required'] = $data->required ? 'true' : null;
+$attributes['onchange']      = $data->element['onchange'] ? (string) $data->element['onchange'] : null;
+
+if ((string) $data->element['readonly'] == 'true' || (string) $data->element['disabled'] == 'true')
+{
+	$attributes['disabled'] = 'disabled';
+}
+
+$renderedAttributes = null;
+
+if ($attributes)
+{
+	foreach ($attributes as $attribute => $value)
+	{
+		if (null !== $value)
+		{
+			$renderedAttributes .= ' ' . $attribute . '="' . (string) $value . '"';
+		}
+	}
+}
+
+$readOnly = ((string) $data->element['readonly'] == 'true');
+
+// If it's readonly the select will have no name
+$selectName = $readOnly ? '' : $data->name;
+?>
+
+<select name="<?php echo $selectName; ?>" <?php echo $renderedAttributes; ?>>
+	<?php if ($data->options) : ?>
+		<?php foreach ($data->options as $option) :?>
+				<option
+					value="<?php echo $option->value; ?>"
+					<?php if ((is_array($data->value) && in_array($option->value, $data->value)) || (!is_array($data->value) && $option->value == $data->value)):
+						echo 'selected="selected"';
+					endif; ?>><?php echo $option->text; ?></option>
+		<?php endforeach; ?>
+	<?php endif; ?>
+</select>
+<?php if ((string) $data->element['readonly'] == 'true') : ?>
+	<input type="hidden" name="<?php echo $data->name; ?>" value="<?php echo $data->value; ?>"/>
+<?php endif;


### PR DESCRIPTION
## Description

This pull request creates a proper base system to migrate redCORE fields. It also adds an AJAX token that will be added automatic to all the `RFormFieldChildlist` fields.

Changes include:

* Fields will be in `libraries/redcore/field` instead of `libraries/redcore/fields` to allow autoloading working.
* Fields classes will include the `R` prefix instead of using Joomla core prefix. So we will use: `RFormFieldChildlist` instead of `JFormFieldRchildlist`. That way autoloading works out of the box and our fields have a better naming. 
* When using fields you have to call them with `type="r.childlist"` (prefix.name) instead of the old `type=rchildlist`.
* redCORE layouts will use the redCORE prefix so we will use `redcore.field.childlist` instead of `fields.rchildlist`. This will ensure that our layouts do not conflict with any extension using the same names and also allows that all the overrides for redcore can be found easily inside the redcore folder. 

All the changes are done in a B/C way so old systems using `type="rchildlist"` will keep working (now that class is only extending `RFormFieldChildlist` class). And same for the old layouts. They are still in the `fields/rchildlist.php` but now they are only proxy calls to the right layout.

For now I have only changed completely childlist and created a proxy for the rlist layout. After we decide if we go this way I can change the other fields.

To understand more see:
http://phproberto.com/en/26-joomla-form-fields-rules-right-way

I'd like you to review this @Kixo @jatitoam @javigomez 