### PR TITLE
Avoid queries when no currency is received

### DIFF
--- a/libraries/redcore/helper/currency.php
+++ b/libraries/redcore/helper/currency.php
@@ -41,6 +41,13 @@ final class RHelperCurrency
 	 */
 	public static function getCurrency($currency = 'DKK')
 	{
+		$currency = is_numeric($currency) ? (int) $currency : trim($currency);
+
+		if (!$currency)
+		{
+			return null;
+		}
+
 		if (!isset(self::$currencies[(string) $currency]))
 		{
 			$db    = JFactory::getDbo();


### PR DESCRIPTION
In another project this `RHelperCurrency::getCurrency()` is called without having a real currency code. This could be solved there by removing calls but I think is ok to also avoid doing queries when a wrong currency has been passed.

This saves me 16 queries:
![currency-queries](https://cloud.githubusercontent.com/assets/1119272/10603550/df5f5986-771e-11e5-84e7-72d37597af6f.png)
