### PR TITLE
Only remove list models context for filter + list

### DIFF
--- a/libraries/redcore/model/list.php
+++ b/libraries/redcore/model/list.php
@@ -240,15 +240,16 @@ abstract class RModelList extends JModelList
 		$app = JFactory::getApplication();
 
 		$data = array(
-			'filter' => $app->getUserStateFromRequest($this->context . '.filter', 'filter', array(), 'array'),
-			'list'   => $app->getUserStateFromRequest($this->context . '.list', 'list', array(), 'array')
+			'filter' => $app->input->get('filter', array(), 'array'),
+			'list'   => $app->input->get('list', array(), 'array')
 		);
 
 		$filterForm = $this->getForm($data, false);
 
 		$data = $filterForm ? $this->validate($filterForm, $data) : array();
 
-		$app->setUserState($this->context, $data);
+		$app->setUserState($this->context . '.filter', empty($data['filter']) ? array() : $data['filter']);
+		$app->setUserState($this->context . '.list', empty($data['list']) ? array() : $data['list']);
 
 		$limit = 0;
 


### PR DESCRIPTION
This fixes an issue caused by https://github.com/redCOMPONENT-COM/redCORE/commit/4f823cec4d77eb29d8396fa19c0d4b81510235c3

## The issue

When no data is received from request the model was forcing all the model state to be an empty array:

```php
$app->setUserState($this->context, $data);
```

That means that if your model is using another context var for something else it gets removed automatically. Let's say that I use something like this in my model's populateState:

```php
$filterProductId = $this->getUserStateFromRequest($this->context . '.product_id', 'product_id');
```

When the page is reloaded that filter (that should be kept in session) is deleted. 

### The solution

Now I'm only overwritting information for `filter` & `list` which is the only information that is automatically processed from the request by the system.