### PR TITLE
Infinite loop when using getState() in getForm() or preprocessForm()

### DIFF
--- a/libraries/redcore/layouts/searchtools/default/filters.php
+++ b/libraries/redcore/layouts/searchtools/default/filters.php
@@ -27,9 +27,13 @@ $filters = $data['view']->filterForm->getGroup('filter');
 <?php if ($filters) : ?>
 	<?php foreach ($filters as $fieldName => $field) : ?>
 		<?php if ($fieldName != $searchField) : ?>
-			<div class="js-stools-field-filter">
+			<?php if ($field->hidden) : ?>
 				<?php echo $field->input; ?>
-			</div>
+			<?php else : ?>
+				<div class="js-stools-field-filter">
+					<?php echo $field->input; ?>
+				</div>
+			<?php endif; ?>
 		<?php endif; ?>
 	<?php endforeach; ?>
 <?php endif;

--- a/libraries/redcore/layouts/searchtools/default/list.bs3.php
+++ b/libraries/redcore/layouts/searchtools/default/list.bs3.php
@@ -17,9 +17,13 @@ $list = $data['view']->filterForm->getGroup('list');
 <?php if ($list) : ?>
 	<div class="ordering-select hidden-xs">
 		<?php foreach ($list as $fieldName => $field) : ?>
-			<div class="js-stools-field-list">
+			<?php if ($field->hidden) : ?>
 				<?php echo $field->input; ?>
-			</div>
+			<?php else : ?>
+				<div class="js-stools-field-list">
+					<?php echo $field->input; ?>
+				</div>
+			<?php endif; ?>
 		<?php endforeach; ?>
 	</div>
 <?php endif;

--- a/libraries/redcore/layouts/searchtools/default/list.php
+++ b/libraries/redcore/layouts/searchtools/default/list.php
@@ -17,9 +17,13 @@ $list = $data['view']->filterForm->getGroup('list');
 <?php if ($list) : ?>
 	<div class="ordering-select hidden-phone">
 		<?php foreach ($list as $fieldName => $field) : ?>
-			<div class="js-stools-field-list">
+			<?php if ($field->hidden) : ?>
 				<?php echo $field->input; ?>
-			</div>
+			<?php else : ?>
+				<div class="js-stools-field-list">
+					<?php echo $field->input; ?>
+				</div>
+			<?php endif; ?>
 		<?php endforeach; ?>
 	</div>
 <?php endif;


### PR DESCRIPTION
I hope this is the last patch for the list models but who knows.....

There was an issue reported by @julienV which caused infinite loops when models use `getForm()` or `preprocessForm()` methods. That's because `populateState()` also used `getForm()` to filter form data. 

This patch uses a new private method (cannot be overriden in child classes) getFormInstance() to load the filter form. That ensures that we won't have conflicts.

It's still not a perfect patch because any filter form modification done in preprocessForm won't be applied for the validation but at this point I think is a small lose that won't affect us.

I have also modified the searchtools layouts so if they receive a filter/list field that is hidden they won't show the wrapper around them because it may cause display issues.