### PR TITLE
REDCORE-446_update_gulp_scripts

### DIFF
--- a/build/gulp-redcore/cli/cli.js
+++ b/build/gulp-redcore/cli/cli.js
@@ -1,15 +1,15 @@
 var gulp = require('gulp');
 
-// Third part extension using redCORE
+// Third part extension using redCORE / redCORE build folder
 try {
-	var config = require('../../../../build/gulp-config.json');
+	var config = require(process.cwd() + '/gulp-config.json');
+	var extensions = require(process.cwd() + '/gulp-extensions.json');
 }
-// redCORE repo
+// redCORE repo relative
 catch(err) {
-	var config = require('../../../build/gulp-config.json');
+	var config = require('../../build/gulp-config.json');
+	var extensions = require('../../build/gulp-extensions.json');
 }
-
-var extensions = require('../../../build/gulp-extensions.json');
 
 /**
  * Get the list of the cli from paths

--- a/build/gulp-redcore/cli/redcore.js
+++ b/build/gulp-redcore/cli/redcore.js
@@ -1,13 +1,13 @@
 var gulp = require('gulp');
 var fs   = require('fs');
 
-// Third part extension using redCORE
+// Third part extension using redCORE / redCORE build folder
 try {
-	var config = require('../../../../build/gulp-config.json');
+	var config = require(process.cwd() + '/gulp-config.json');
 }
-// redCORE repo
+// redCORE repo relative
 catch(err) {
-	var config = require('../../../build/gulp-config.json');
+	var config = require('../../build/gulp-config.json');
 }
 
 // Dependencies

--- a/build/gulp-redcore/components/redcore.js
+++ b/build/gulp-redcore/components/redcore.js
@@ -1,13 +1,13 @@
 var gulp = require('gulp');
 var fs   = require('fs');
 
-// Third part extension using redCORE
+// Third part extension using redCORE / redCORE build folder
 try {
-	var config = require('../../../../build/gulp-config.json');
+	var config = require(process.cwd() + '/gulp-config.json');
 }
-// redCORE repo
+// redCORE repo relative
 catch(err) {
-	var config = require('../../../build/gulp-config.json');
+	var config = require('../../build/gulp-config.json');
 }
 
 // Dependencies

--- a/build/gulp-redcore/libraries/redcore.js
+++ b/build/gulp-redcore/libraries/redcore.js
@@ -1,13 +1,13 @@
 var gulp = require('gulp');
 var fs   = require('fs');
 
-// Third part extension using redCORE
+// Third part extension using redCORE / redCORE build folder
 try {
-	var config = require('../../../../build/gulp-config.json');
+	var config = require(process.cwd() + '/gulp-config.json');
 }
-// Called directly from redCORE
+// redCORE repo relative
 catch(err) {
-	var config = require('../../../build/gulp-config.json');
+	var config = require('../../build/gulp-config.json');
 }
 
 // Dependencies

--- a/build/gulp-redcore/main.js
+++ b/build/gulp-redcore/main.js
@@ -1,10 +1,10 @@
 var gulp = require('gulp');
 
-// Third part extension using redCORE
+// Third part extension using redCORE / redCORE build folder
 try {
-	var config = require('../../../build/gulp-config.json');
+	var config = require(process.cwd() + '/gulp-config.json');
 }
-// redCORE repo
+// redCORE repo relative
 catch(err) {
 	var config = require('../../build/gulp-config.json');
 }

--- a/build/gulp-redcore/media/redcore.js
+++ b/build/gulp-redcore/media/redcore.js
@@ -1,12 +1,13 @@
 var gulp = require('gulp');
 var fs   = require('fs');
 
-// Third part extension using redCORE
+// Third part extension using redCORE / redCORE build folder
 try {
-	var config = require('../../../../build/gulp-config.json');
+	var config = require(process.cwd() + '/gulp-config.json');
 }
+// redCORE repo relative
 catch(err) {
-	var config = require('../../../build/gulp-config.json');
+	var config = require('../../build/gulp-config.json');
 }
 
 // Dependencies

--- a/build/gulp-redcore/modules/site/redcore_langswitcher.js
+++ b/build/gulp-redcore/modules/site/redcore_langswitcher.js
@@ -1,10 +1,11 @@
 var gulp = require('gulp');
 var fs   = require('fs');
 
-// Third part extension using redCORE
+// Third part extension using redCORE / redCORE build folder
 try {
-	var config = require('../../../../../build/gulp-config.json');
+	var config = require(process.cwd() + '/gulp-config.json');
 }
+// redCORE repo relative
 catch(err) {
 	var config = require('../../../../build/gulp-config.json');
 }

--- a/build/gulp-redcore/plugins/redpayment/paypal.js
+++ b/build/gulp-redcore/plugins/redpayment/paypal.js
@@ -1,10 +1,11 @@
 var gulp = require('gulp');
 var fs   = require('fs');
 
-// Third part extension using redCORE
+// Third part extension using redCORE / redCORE build folder
 try {
-	var config = require('../../../../../build/gulp-config.json');
+	var config = require(process.cwd() + '/gulp-config.json');
 }
+// redCORE repo relative
 catch(err) {
 	var config = require('../../../../build/gulp-config.json');
 }

--- a/build/gulp-redcore/plugins/system/mvcoverride.js
+++ b/build/gulp-redcore/plugins/system/mvcoverride.js
@@ -1,10 +1,11 @@
 var gulp = require('gulp');
 var fs   = require('fs');
 
-// Third part extension using redCORE
+// Third part extension using redCORE / redCORE build folder
 try {
-	var config = require('../../../../../build/gulp-config.json');
+	var config = require(process.cwd() + '/gulp-config.json');
 }
+// redCORE repo relative
 catch(err) {
 	var config = require('../../../../build/gulp-config.json');
 }

--- a/build/gulp-redcore/plugins/system/redcore.js
+++ b/build/gulp-redcore/plugins/system/redcore.js
@@ -1,10 +1,11 @@
 var gulp = require('gulp');
 var fs   = require('fs');
 
-// Third part extension using redCORE
+// Third part extension using redCORE / redCORE build folder
 try {
-	var config = require('../../../../../build/gulp-config.json');
+	var config = require(process.cwd() + '/gulp-config.json');
 }
+// redCORE repo relative
 catch(err) {
 	var config = require('../../../../build/gulp-config.json');
 }

--- a/build/gulp-redcore/webservices/redcore.js
+++ b/build/gulp-redcore/webservices/redcore.js
@@ -1,13 +1,13 @@
 var gulp = require('gulp');
 var fs   = require('fs');
 
-// Third part extension using redCORE
+// Third part extension using redCORE / redCORE build folder
 try {
-	var config = require('../../../../build/gulp-config.json');
+	var config = require(process.cwd() + '/gulp-config.json');
 }
-// redCORE repo
+// redCORE repo relative
 catch(err) {
-	var config = require('../../../build/gulp-config.json');
+	var config = require('../../build/gulp-config.json');
 }
 
 // Dependencies

--- a/build/gulp-redcore/webservices/webservices.js
+++ b/build/gulp-redcore/webservices/webservices.js
@@ -1,15 +1,15 @@
 var gulp = require('gulp');
 
-// Third part extension using redCORE
+// Third part extension using redCORE / redCORE build folder
 try {
-	var config = require('../../../../build/gulp-config.json');
+	var config = require(process.cwd() + '/gulp-config.json');
+	var extensions = require(process.cwd() + '/gulp-extensions.json');
 }
-// redCORE repo
+// redCORE repo relative
 catch(err) {
-	var config = require('../../../build/gulp-config.json');
+	var config = require('../../build/gulp-config.json');
+	var extensions = require('../../build/gulp-extensions.json');
 }
-
-var extensions = require('../../../build/gulp-extensions.json');
 
 /**
  * Get the list of the webservices from paths


### PR DESCRIPTION
set a absolute path for the process make it more easy to pinpoint where are we instead of standard ../../../../ paths... this will make sure that redCORE gulp scripts work placed in any project folder