### PR TITLE
Fixes Soap Api ReadItem Bug 

### DIFF
--- a/extensions/libraries/redcore/api/soap/helper.php
+++ b/extensions/libraries/redcore/api/soap/helper.php
@@ -271,7 +271,7 @@ class RApiSoapHelper
 			{
 				$object = new stdClass;
 
-				foreach ($item['fields'] as $field => $value)
+				foreach ($item as $field => $value)
 				{
 					if (in_array($field, $outputResources))
 					{

--- a/extensions/libraries/redcore/api/soap/helper.php
+++ b/extensions/libraries/redcore/api/soap/helper.php
@@ -270,14 +270,12 @@ class RApiSoapHelper
 			foreach ($items as $item)
 			{
 				$object = new stdClass;
-				$i = 0;
 
-				foreach ($item as $field => $value)
+				foreach ($item['fields'] as $field => $value)
 				{
 					if (in_array($field, $outputResources))
 					{
 						$object->$field = $value;
-						$i++;
 					}
 				}
 

--- a/extensions/libraries/redcore/api/soap/operation/operation.php
+++ b/extensions/libraries/redcore/api/soap/operation/operation.php
@@ -140,6 +140,11 @@ class RApiSoapOperationOperation
 		$arr = $this->webservice->hal->toArray();
 		$outputResources = RApiSoapHelper::getOutputResources($this->webservice->configuration->operations->read->item, '', true);
 
+		if (array_key_exists('fields', $arr))
+		{
+			$arr = $arr['fields'];
+		}
+
 		$response = RApiSoapHelper::selectListResources($outputResources, array($arr));
 
 		$final = new stdClass;


### PR DESCRIPTION
https://redweb.atlassian.net/browse/RSBTB-3036
https://redweb.atlassian.net/browse/RSBTB-3039

The item being passed into this method from the HAL webservice were in the format

array( [0] => array('fields' => array($field => $value), '_messages' => array())

So when we were looping through with foreach($item as $field -> $value) 
field would be either fields or _messages.