### PR TITLE
RSBTB-2548 #comment allow send values in POST request

### DIFF
--- a/extensions/libraries/redcore/api/hal/hal.php
+++ b/extensions/libraries/redcore/api/hal/hal.php
@@ -298,10 +298,11 @@ class RApiHalHal extends RApi
 			case 'DELETE':
 				$method = 'DELETE';
 				break;
+		}
 
-			default:
-				$method = 'READ';
-				break;
+		if (!$method)
+		{
+			$method = 'READ';
 		}
 
 		// If task is pointing to some other operation like apply, update or delete

--- a/extensions/plugins/system/redcore/redcore.php
+++ b/extensions/plugins/system/redcore/redcore.php
@@ -85,10 +85,10 @@ class PlgSystemRedcore extends JPlugin
 						$version = $input->getString('webserviceVersion', '');
 						$token = $input->getString(RBootstrap::getConfig('oauth2_token_param_name', 'access_token'), '');
 						$apiName = ucfirst($apiName);
-						$method = strtoupper($input->getMethod());
+						$method = strtoupper($input->getCmd('method', $input->getMethod()));
 						$task = RApiHalHelper::getTask();
 						$data = RApi::getPostedData();
-						$dataGet = $input->get->getArray();
+						$dataGet = $input->getArray();
 
 						if (empty($webserviceClient))
 						{


### PR DESCRIPTION
@jatitoam @Kixo please review thats PR.
I want to send many condition values for READ, but GET request have length restrictions and it cold be not enought, so i need use POST instead.
Thats code help me do that, because here https://github.com/redCOMPONENT-COM/redCORE/blob/develop/extensions/libraries/redcore/api/hal/hal.php#L296 my method change to CREATE.
So after fix i will have sent `method=READ` and any request type.
If you see another variants do that - i listen you.