### PR TITLE
[fix] Fixed paypal callback

### DIFF
--- a/extensions/plugins/redpayment/paypal/helpers/payment.php
+++ b/extensions/plugins/redpayment/paypal/helpers/payment.php
@@ -137,6 +137,9 @@ class PaymentHelperPaypal extends RApiPaymentPluginHelperPayment
 			   check that receiver_email is your Primary PayPal email
 			   check that payment_amount/payment_currency are correct */
 
+			// Remap order_id
+			$data['order_id'] = $data['invoice'];
+
 			$payment = $this->getPaymentByExtensionOrderData($extensionName, $data);
 
 			if ($post['mc_gross'] != $payment->amount_total)


### PR DESCRIPTION
I find it strange that nobody noticed, or maybe nobody is actually using this gaeway... but the callback is not working, as the order_id is mapped to invoice, and not remapped back to retrieve that payment,