### PR TITLE
Rsbtb 3588 add a empty field option through api

### DIFF
--- a/extensions/libraries/redcore/api/hal/hal.php
+++ b/extensions/libraries/redcore/api/hal/hal.php
@@ -1475,15 +1475,13 @@ class RApiHalHal extends RApi
 				// If field is not sent through Request
 				if (!isset($data[$fieldAttributes['name']]))
 				{
-					// If this is a create operation then we will populate missing fields with default values if they are not empty
+					// We will populate missing fields with null value
+					$data[$fieldAttributes['name']] = null;
+
+					// We will populate value with default value if the field is not set for create operation
 					if ($this->operation == 'create')
 					{
 						$data[$fieldAttributes['name']] = $fieldAttributes['defaultValue'];
-					}
-					// If this is not create operation we will populate missing fields with null value
-					else
-					{
-						$data[$fieldAttributes['name']] = null;
 					}
 				}
 

--- a/extensions/libraries/redcore/api/hal/hal.php
+++ b/extensions/libraries/redcore/api/hal/hal.php
@@ -1472,12 +1472,23 @@ class RApiHalHal extends RApi
 				$fieldAttributes['defaultValue'] = !is_null($fieldAttributes['defaultValue'])
 					&& !RApiHalHelper::isAttributeTrue($fieldAttributes, 'isPrimaryField') ? $fieldAttributes['defaultValue'] : '';
 
-				if (!isset($data[$fieldAttributes['name']]) || is_null($data[$fieldAttributes['name']]))
+				if (!isset($data[$fieldAttributes['name']]))
 				{
-					$data[$fieldAttributes['name']] = $fieldAttributes['defaultValue'];
+					if ($this->operation == 'create' && !empty($fieldAttributes['defaultValue']))
+					{
+						$data[$fieldAttributes['name']] = $fieldAttributes['defaultValue'];
+					}
+					else
+					{
+						$data[$fieldAttributes['name']] = null;
+					}
 				}
 
-				$data[$fieldAttributes['name']] = $this->transformField($fieldAttributes['transform'], $data[$fieldAttributes['name']], false);
+				if (!is_null($data[$fieldAttributes['name']]))
+				{
+					$data[$fieldAttributes['name']] = $this->transformField($fieldAttributes['transform'], $data[$fieldAttributes['name']], false);
+				}
+
 				$dataFields[$fieldAttributes['name']] = $data[$fieldAttributes['name']];
 			}
 

--- a/extensions/libraries/redcore/api/hal/hal.php
+++ b/extensions/libraries/redcore/api/hal/hal.php
@@ -1472,12 +1472,15 @@ class RApiHalHal extends RApi
 				$fieldAttributes['defaultValue'] = !is_null($fieldAttributes['defaultValue'])
 					&& !RApiHalHelper::isAttributeTrue($fieldAttributes, 'isPrimaryField') ? $fieldAttributes['defaultValue'] : '';
 
+				// If field is not sent through Request
 				if (!isset($data[$fieldAttributes['name']]))
 				{
-					if ($this->operation == 'create' && !empty($fieldAttributes['defaultValue']))
+					// If this is a create operation then we will populate missing fields with default values if they are not empty
+					if ($this->operation == 'create')
 					{
 						$data[$fieldAttributes['name']] = $fieldAttributes['defaultValue'];
 					}
+					// If this is not create operation we will populate missing fields with null value
 					else
 					{
 						$data[$fieldAttributes['name']] = null;


### PR DESCRIPTION
so basically with this PR we dont populate every missing field with default values, and fields set as null to default value, but instead we leave null as a value capable of passing to the model.

So if the field is not sent (through request) it will be set as null, unless that operation is create then it will take default value.