### PR TITLE
Translation improvement

### DIFF
--- a/extensions/components/com_redcore/admin/controllers/webservice.php
+++ b/extensions/components/com_redcore/admin/controllers/webservice.php
@@ -318,7 +318,7 @@ class RedcoreControllerWebservice extends RControllerForm
 		$model = $this->getModel();
 		$id = $input->getInt('id', null);
 		$model->getItem($id);
-		
+
 		$operation = $input->getString('operation', 'read');
 		$fieldList = $input->getString('fieldList', '');
 

--- a/extensions/components/com_redcore/admin/layouts/sidebar.bs3.php
+++ b/extensions/components/com_redcore/admin/layouts/sidebar.bs3.php
@@ -14,7 +14,7 @@ $view = RInflector::pluralize($app->input->getString('view', ''));
 $return = $app->input->getString('return', '');
 $translationTableName = $app->input->getString('translationTableName', '');
 $components = RedcoreHelpersView::getExtensionsRedcore(true);
-$translationTables = RTranslationTable::getInstalledTranslationTables();
+$translationTables = RTranslationTable::getInstalledTranslationTables(false, true);
 ?>
 <div class="panel-group" id="rc-sidebar-accordion">
 	<div class="panel panel-default">

--- a/extensions/libraries/redcore/menu/menu.php
+++ b/extensions/libraries/redcore/menu/menu.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_REDCORE') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Represents a menu.
  * A menu is a set of trees.
@@ -86,7 +88,7 @@ class RMenu
 			$item = $menu->getItem($item->id);
 
 			// Decode the item params
-			$result = new JRegistry;
+			$result = new Registry;
 			$result->loadString($item->params);
 			$item->params = $result;
 		}

--- a/extensions/libraries/redcore/translation/table.php
+++ b/extensions/libraries/redcore/translation/table.php
@@ -995,7 +995,7 @@ final class RTranslationTable
 	{
 		static $fullLoaded;
 
-		if ($fullLoad && !$fullLoaded)
+		if ($fullLoad && (is_null($fullLoaded) || !$fullLoaded))
 		{
 			$db = JFactory::getDbo();
 			$oldTranslate = isset($db->translate) ? $db->translate : false;
@@ -1076,7 +1076,7 @@ final class RTranslationTable
 			self::$installedTranslationTables = $tables;
 		}
 
-		if ($isEnabled)
+		if ($isEnabled && $fullLoaded)
 		{
 			$tables = self::$installedTranslationTables;
 

--- a/extensions/libraries/redcore/translation/table.php
+++ b/extensions/libraries/redcore/translation/table.php
@@ -986,7 +986,8 @@ final class RTranslationTable
 	/**
 	 * Get list of all translation tables with columns
 	 *
-	 * @param   bool  $fullLoad  Full load tables
+	 * @param   bool  $fullLoad   Full load tables
+	 * @param   bool  $isEnabled  If true is just return "Enabled" translation table.
 	 *
 	 * @return  array  Array or table with columns columns
 	 */

--- a/extensions/libraries/redcore/translation/table.php
+++ b/extensions/libraries/redcore/translation/table.php
@@ -1031,7 +1031,7 @@ final class RTranslationTable
 			$fullLoaded = true;
 		}
 
-		if ($fullLoad && !isset(self::$installedTranslationTables))
+		if (!$fullLoad && !isset(self::$installedTranslationTables))
 		{
 			$db = JFactory::getDbo();
 			$oldTranslate = isset($db->translate) ? $db->translate : false;

--- a/extensions/libraries/redcore/translation/table.php
+++ b/extensions/libraries/redcore/translation/table.php
@@ -990,7 +990,7 @@ final class RTranslationTable
 	 *
 	 * @return  array  Array or table with columns columns
 	 */
-	public static function getInstalledTranslationTables($fullLoad = false)
+	public static function getInstalledTranslationTables($fullLoad = false, $isEnabled = false)
 	{
 		static $fullLoaded;
 
@@ -1031,7 +1031,7 @@ final class RTranslationTable
 			$fullLoaded = true;
 		}
 
-		if (!$fullLoad && !isset(self::$installedTranslationTables))
+		if ($fullLoad && !isset(self::$installedTranslationTables))
 		{
 			$db = JFactory::getDbo();
 			$oldTranslate = isset($db->translate) ? $db->translate : false;
@@ -1073,6 +1073,21 @@ final class RTranslationTable
 			// We put translation check back on
 			$db->translate = $oldTranslate;
 			self::$installedTranslationTables = $tables;
+		}
+
+		if ($isEnabled)
+		{
+			$tables = self::$installedTranslationTables;
+
+			foreach ($tables as $key => $table)
+			{
+				if (!$table->state)
+				{
+					unset($tables[$key]);
+				}
+			}
+
+			return $tables;
 		}
 
 		return self::$installedTranslationTables;

--- a/extensions/plugins/system/redcore/redcore.php
+++ b/extensions/plugins/system/redcore/redcore.php
@@ -18,6 +18,8 @@ defined('JPATH_BASE') or die;
  */
 class PlgSystemRedcore extends JPlugin
 {
+	static $oldLanguage;
+
 	/**
 	 * Constructor
 	 *
@@ -166,8 +168,21 @@ class PlgSystemRedcore extends JPlugin
 	{
 		if (defined('REDCORE_LIBRARY_LOADED'))
 		{
-			if (RTranslationHelper::getSiteLanguage() != JFactory::getLanguage()->getTag())
+			$app     = JFactory::getApplication();
+			$oldLang = $app->getUserState('redcore.old_lang', null);
+
+			if (RTranslationHelper::getSiteLanguage() != JFactory::getLanguage()->getTag()
+				|| (!empty($oldLang) && JFactory::getLanguage()->getTag() != $oldLang))
 			{
+				if ($oldLang == RTranslationHelper::getSiteLanguage())
+				{
+					$app->setUserState('redcore.old_lang', null);
+				}
+				else
+				{
+					$app->setUserState('redcore.old_lang', JFactory::getLanguage()->getTag());
+				}
+
 				// Reset menus because they are loaded before any other module
 				RMenu::resetJoomlaMenuItems();
 			}

--- a/extensions/plugins/system/redcore/redcore.php
+++ b/extensions/plugins/system/redcore/redcore.php
@@ -174,14 +174,7 @@ class PlgSystemRedcore extends JPlugin
 			if (RTranslationHelper::getSiteLanguage() != JFactory::getLanguage()->getTag()
 				|| (!empty($oldLang) && JFactory::getLanguage()->getTag() != $oldLang))
 			{
-				if ($oldLang == RTranslationHelper::getSiteLanguage())
-				{
-					$app->setUserState('redcore.old_lang', null);
-				}
-				else
-				{
-					$app->setUserState('redcore.old_lang', JFactory::getLanguage()->getTag());
-				}
+				$app->setUserState('redcore.old_lang', JFactory::getLanguage()->getTag());
 
 				// Reset menus because they are loaded before any other module
 				RMenu::resetJoomlaMenuItems();

--- a/extensions/plugins/system/redcore/redcore.php
+++ b/extensions/plugins/system/redcore/redcore.php
@@ -18,8 +18,6 @@ defined('JPATH_BASE') or die;
  */
 class PlgSystemRedcore extends JPlugin
 {
-	static $oldLanguage;
-
 	/**
 	 * Constructor
 	 *


### PR DESCRIPTION
This PR for 2 point:

**[Fix] Menu doesn't translate:**
Preprocedure this bug:
- Install new language "Vietnamese (vi-VN)".
- Set default site language is "en-GB".
- Translate menu with this new language.
- Enable plugin "Language Filter"
- Enable module "Redcore - Language Switch"
- At home page ("en-GB") => Switch to "vi-VN" => Menu translated.
- At this page ("vi-VN") => Switch to "en-GB" => Menu not transated. => Refresh page => Menu translated.
Reason: It's just happen because the switched language is default so that menu doesn't re-load and keep translated title (In this case is still VN).

**[Improvement] Manage Translate Content**
- In redCORE backend.
- Hide tables which have state "unpublish".