### PR TITLE
[fix] missing message container

### DIFF
--- a/extensions/libraries/redcore/layouts/component/admin.bs3.php
+++ b/extensions/libraries/redcore/layouts/component/admin.bs3.php
@@ -159,8 +159,18 @@ if ($result instanceof Exception)
 }
 ?>
 <script type="text/javascript">
-	jQuery(document).ready(function () {
-		jQuery('.message-sys').append(jQuery('#system-message-container'));
+(function ($) {
+    $(document).ready(function () {
+
+        if ($('.message-sys').length) {
+            var messageContainer = $('#system-message-container');
+
+            // No messages found. Create an empty div
+            if (!messageContainer.length) {
+                messageContainer = $("<div>", {id: "system-message-container"});
+            }
+            $('.message-sys').append(messageContainer);
+        }
 
 		<?php if ($input->getBool('disable_topbar') || $input->getBool('hidemainmenu')) : ?>
 		jQuery('.topbar').addClass('opacity-70');
@@ -174,6 +184,7 @@ if ($result instanceof Exception)
 		jQuery('.sidebar a').attr('disabled', true).attr('href', '#').addClass('disabled');
 		<?php endif; ?>
 	});
+})(jQuery);
 </script>
 <?php if ($view->getLayout() === 'modal') : ?>
 	<div class="row redcore">

--- a/extensions/libraries/redcore/layouts/component/admin.php
+++ b/extensions/libraries/redcore/layouts/component/admin.php
@@ -159,8 +159,18 @@ if ($result instanceof Exception)
 }
 ?>
 <script type="text/javascript">
-	jQuery(document).ready(function () {
-		jQuery('.message-sys').append(jQuery('#system-message-container'));
+(function ($) {
+    $(document).ready(function () {
+
+        if ($('.message-sys').length) {
+            var messageContainer = $('#system-message-container');
+
+            // No messages found. Create an empty div
+            if (!messageContainer.length) {
+                messageContainer = $("<div>", {id: "system-message-container"});
+            }
+            $('.message-sys').append(messageContainer);
+        }
 
 		<?php if ($input->getBool('disable_topbar') || $input->getBool('hidemainmenu')) : ?>
 		jQuery('.topbar').addClass('opacity-70');
@@ -174,6 +184,7 @@ if ($result instanceof Exception)
 		jQuery('.sidebar a').attr('disabled', true).attr('href', '#').addClass('disabled');
 		<?php endif; ?>
 	});
+})(jQuery);
 </script>
 <?php if ($view->getLayout() === 'modal') : ?>
 	<div class="row-fluid redcore">


### PR DESCRIPTION
This [pull request](https://github.com/redCOMPONENT-COM/redCORE/pull/721) partially solved the permissions issue.

When there is no message container you get a JS error like:

`TypeError: messageContainer is null`

Because the message container is not found and joomla core javascript tries to remove messages on it. This ensure that we always have a message container.