### PR TITLE
[fix] cannot instantiate model with duplicated model names

### DIFF
--- a/extensions/libraries/redcore/model/model.php
+++ b/extensions/libraries/redcore/model/model.php
@@ -88,14 +88,14 @@ abstract class RModel extends JModelLegacy
 		// Admin
 		if ($client === 1)
 		{
-			self::addIncludePath(JPATH_ADMINISTRATOR . '/components/' . $option . '/models');
+			self::addIncludePath(JPATH_ADMINISTRATOR . '/components/' . $option . '/models', $prefix);
 			JTable::addIncludePath(JPATH_ADMINISTRATOR . '/components/' . $option . '/tables');
 		}
 
 		// Site
 		elseif ($client === 0)
 		{
-			self::addIncludePath(JPATH_SITE . '/components/' . $option . '/models');
+			self::addIncludePath(JPATH_SITE . '/components/' . $option . '/models', $prefix);
 			JTable::addIncludePath(JPATH_SITE . '/components/' . $option . '/tables');
 		}
 


### PR DESCRIPTION
When more than one component registers the same model name than other component you can get `Cannot instanciate the model %s in component %s` errors.

We have experienced this on a site after upgrading it to Joomla 3.7.0 because Joomla has now a `Fields` model which uses the same name than our `Fields` model.

This should be a fully B/C change because we are already calculating the prefix. The only change is using it to store the lookup folders.