### PR TITLE
[fix] fixed invalid appending of get var on seo return url

### DIFF
--- a/extensions/libraries/redcore/controller/form.php
+++ b/extensions/libraries/redcore/controller/form.php
@@ -755,6 +755,11 @@ class RControllerForm extends JControllerForm
 		{
 			$returnUrl = base64_decode($returnUrl);
 
+			if (!strstr($returnUrl, '?') && $append && $append[0] == '&')
+			{
+				$append[0] = '?';
+			}
+
 			return JRoute::_($returnUrl . $append, false);
 		}
 		else


### PR DESCRIPTION
when the return url is pure sef, without ?, make sure the append string starts with ? instead of &